### PR TITLE
SplitView fixes

### DIFF
--- a/src/UniversalWPF/Themes/Generic.xaml
+++ b/src/UniversalWPF/Themes/Generic.xaml
@@ -348,8 +348,6 @@
 																   To="*" BeginTime="0:0:0"/>
                                 <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
 																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-                                <Int32Animation Storyboard.TargetProperty="Width" Storyboard.TargetName="ColumnDefinition2"
-											BeginTime="0:0:0" To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" />
                                 <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
 											 BeginTime="0:0:0" To="1"/>
                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">

--- a/src/UniversalWPF/Themes/Generic.xaml
+++ b/src/UniversalWPF/Themes/Generic.xaml
@@ -18,405 +18,395 @@
 					<Grid Background="{TemplateBinding Background}" x:Name="root" Tag="{TemplateBinding TemplateSettings}">
 						<Grid.Resources>
 							<FrameworkElement x:Key="ProxyElement" DataContext="{TemplateBinding TemplateSettings}" />
-						</Grid.Resources>
-						<Grid.ColumnDefinitions>
+                            <Storyboard x:Key="ClosedToOpenOverlayLeft">
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.NegativeOpenPaneLength, Source={StaticResource ProxyElement}}"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="ClosedToOpenOverlayRight">
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Right</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Left</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.NegativeOpenPaneLength, ElementName=ProxyElement}"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="ClosedCompactLeftToOpenCompactOverlayLeft">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0" />
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0" />
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.NegativeOpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="ClosedCompactRightToOpenCompactOverlayRight">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="*" BeginTime="0:0:0"/>
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+												BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Right</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Left</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.OpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="OpenOverlayLeftToClosed">
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.NegativeOpenPaneLength, ElementName=ProxyElement}"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="OpenOverlayRightToClosed">
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Right</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Left</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.NegativeOpenPaneLength, ElementName=ProxyElement}"/>
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="OpenCompactOverlayLeftToClosedCompactLeft">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot"
+												BeginTime="0:0:0" To="1"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+												BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.NegativeOpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="OpenCompactOverlayRightToClosedCompactRight">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="*" BeginTime="0:0:0"/>
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+												BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Right</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Left</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
+                                    <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.OpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+
+                            <Storyboard x:Key="ClosedCompactLeftStoryboard">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimation Duration="0:0:0" To="{Binding DataContext.NegativeOpenPaneLengthMinusCompactLength, ElementName=ProxyElement}" Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform"/>
+                            </Storyboard>
+                            <Storyboard x:Key="ClosedCompactRightStoryboard">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="*" BeginTime="0:0:0"/>
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+											 BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
+											BeginTime="0:0:0" To="2" />
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Right</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <DoubleAnimation Duration="0:0:0" To="{Binding DataContext.OpenPaneLengthMinusCompactLength, ElementName=ProxyElement}" Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform"/>
+                            </Storyboard>
+
+                            <Storyboard x:Key="OpenOverlayLeftStoryboard">
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="OpenOverlayRightStoryboard">
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Right</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Left</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+
+                            <Storyboard x:Key="OpenInlineLeftStoryboard">
+                                <Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="OpenInlineRightStoryboard">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="*" BeginTime="0:0:0"/>
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
+																   To="{Binding DataContext.OpenPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="PaneRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
+											BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Left</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+
+                            <Storyboard x:Key="OpenCompactOverlayLeftStoryboard">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0" />
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0"  />
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                            <Storyboard x:Key="OpenCompactOverlayRightStoryboard">
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
+																   To="*" BeginTime="0:0:0"/>
+                                <local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
+																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
+                                <Int32Animation Storyboard.TargetProperty="Width" Storyboard.TargetName="ColumnDefinition2"
+											BeginTime="0:0:0" To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" />
+                                <Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
+											 BeginTime="0:0:0" To="1"/>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Right</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                        <DiscreteObjectKeyFrame.Value>
+                                            <HorizontalAlignment>Left</HorizontalAlignment>
+                                        </DiscreteObjectKeyFrame.Value>
+                                    </DiscreteObjectKeyFrame>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </Grid.Resources>
+
+                        <Grid.ColumnDefinitions>
 							<ColumnDefinition x:Name="ColumnDefinition1" Width="{Binding DataContext.OpenPaneGridLength, FallbackValue=0, ElementName=ProxyElement}"/>
 							<ColumnDefinition x:Name="ColumnDefinition2" Width="*"/>
 						</Grid.ColumnDefinitions>
-						<VisualStateManager.VisualStateGroups>
+
+                        <VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="DisplayModeStates">
 								<VisualStateGroup.Transitions>
-									<VisualTransition From="Closed" To="OpenOverlayLeft">
-										<Storyboard>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.NegativeOpenPaneLength, Source={StaticResource ProxyElement}}"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
-											</DoubleAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
-											</DoubleAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
-									<VisualTransition From="Closed" To="OpenOverlayRight">
-										<Storyboard>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Right</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Left</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-                                            </ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
-											</DoubleAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.NegativeOpenPaneLength, ElementName=ProxyElement}"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
-											</DoubleAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
-									<VisualTransition From="ClosedCompactLeft" To="OpenCompactOverlayLeft">
-										<Storyboard>
-											<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-											<Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0" />
-											<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0" />
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.NegativeOpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
-											</DoubleAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
-									<VisualTransition From="ClosedCompactRight" To="OpenCompactOverlayRight">
-										<Storyboard>
-											<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="*" BeginTime="0:0:0"/>
-
-											<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-
-											<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-												BeginTime="0:0:0" To="1"/>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Right</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-                                            </ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Left</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-                                            </ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding DataContext.OpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.35" Value="0"/>
-											</DoubleAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
-									<VisualTransition From="OpenOverlayLeft" To="Closed">
-										<Storyboard>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.NegativeOpenPaneLength, ElementName=ProxyElement}"/>
-											</DoubleAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
-											</DoubleAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
-									<VisualTransition From="OpenOverlayRight" To="Closed">
-										<Storyboard>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Right</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-                                            </ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Left</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-                                            </ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneTransform">
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.OpenPaneLength, ElementName=ProxyElement}"/>
-											</DoubleAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.NegativeOpenPaneLength, ElementName=ProxyElement}"/>
-											</DoubleAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
-									<VisualTransition From="OpenCompactOverlayLeft" To="ClosedCompactLeft">
-										<Storyboard>
-											<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-
-											<Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot"
-												BeginTime="0:0:0" To="1"/>
-											<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-												BeginTime="0:0:0" To="1"/>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.NegativeOpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
-											</DoubleAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
-									<VisualTransition From="OpenCompactOverlayRight" To="ClosedCompactRight">
-										<Storyboard>
-											<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="*" BeginTime="0:0:0"/>
-											<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-											<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-												BeginTime="0:0:0" To="1"/>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Right</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-                                            </ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                    <DiscreteObjectKeyFrame.Value>
-                                                        <HorizontalAlignment>Left</HorizontalAlignment>
-                                                    </DiscreteObjectKeyFrame.Value>
-                                                </DiscreteObjectKeyFrame>
-                                            </ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform">
-												<DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
-												<SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.12" Value="{Binding DataContext.OpenPaneLengthMinusCompactLength, ElementName=ProxyElement}"/>
-											</DoubleAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualTransition>
+                                    <VisualTransition From="Closed" To="OpenOverlayLeft" Storyboard="{StaticResource ClosedToOpenOverlayLeft}" />
+                                    <VisualTransition From="Closed" To="OpenOverlayRight" Storyboard="{StaticResource ClosedToOpenOverlayRight}" />
+                                    <VisualTransition From="ClosedCompactLeft" To="OpenCompactOverlayLeft" Storyboard="{StaticResource ClosedCompactLeftToOpenCompactOverlayLeft}" />
+                                    <VisualTransition From="ClosedCompactRight" To="OpenCompactOverlayRight" Storyboard="{StaticResource ClosedCompactRightToOpenCompactOverlayRight}" />
+                                    <VisualTransition From="OpenOverlayLeft" To="Closed" Storyboard="{StaticResource OpenOverlayLeftToClosed}" />
+                                    <VisualTransition From="OpenOverlayRight" To="Closed" Storyboard="{StaticResource OpenOverlayRightToClosed}" />
+                                    <VisualTransition From="OpenCompactOverlayLeft" To="ClosedCompactLeft" Storyboard="{StaticResource OpenCompactOverlayLeftToClosedCompactLeft}" />
+                                    <VisualTransition From="OpenCompactOverlayRight" To="ClosedCompactRight" Storyboard="{StaticResource OpenCompactOverlayRightToClosedCompactRight}" />
 								</VisualStateGroup.Transitions>
 								<VisualState x:Name="Closed"/>
-								<VisualState x:Name="ClosedCompactLeft">
-									<Storyboard>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-										<Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot"
-											BeginTime="0:0:0" To="1"/>
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-											BeginTime="0:0:0" To="1"/>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<DoubleAnimation Duration="0:0:0" To="{Binding DataContext.NegativeOpenPaneLengthMinusCompactLength, ElementName=ProxyElement}" Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform"/>
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="ClosedCompactRight">
-									<Storyboard>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="*" BeginTime="0:0:0"/>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-											 BeginTime="0:0:0" To="1"/>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
-											BeginTime="0:0:0" To="2" />
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <HorizontalAlignment>Right</HorizontalAlignment>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-										<DoubleAnimation Duration="0:0:0" To="{Binding DataContext.OpenPaneLengthMinusCompactLength, ElementName=ProxyElement}" Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform"/>
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="OpenOverlayLeft">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="OpenOverlayRight">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <HorizontalAlignment>Right</HorizontalAlignment>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <HorizontalAlignment>Left</HorizontalAlignment>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="OpenInlineLeft">
-									<Storyboard>
-										<Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot"
-											BeginTime="0:0:0" To="1"/>
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-											BeginTime="0:0:0" To="1"/>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
-											BeginTime="0:0:0" To="1"/>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="OpenInlineRight">
-									<Storyboard>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="*" BeginTime="0:0:0"/>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
-																   To="{Binding DataContext.OpenPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-											BeginTime="0:0:0" To="1"/>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="PaneRoot"
-											BeginTime="0:0:0" To="1"/>
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
-											BeginTime="0:0:0" To="1"/>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <HorizontalAlignment>Left</HorizontalAlignment>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="OpenCompactOverlayLeft">
-									<Storyboard>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-										<Int32Animation Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0" />
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot" To="1" BeginTime="0:0:0"  />
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="OpenCompactOverlayRight">
-									<Storyboard>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition1" 
-																   To="*" BeginTime="0:0:0"/>
-										<local:GridLengthAnimation Storyboard.TargetProperty="(ColumnDefinition.Width)" Storyboard.TargetName="ColumnDefinition2" 
-																   To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" BeginTime="0:0:0"/>
-										<Int32Animation Storyboard.TargetProperty="Width" Storyboard.TargetName="ColumnDefinition2"
-											BeginTime="0:0:0" To="{Binding DataContext.CompactPaneGridLength, FallbackValue=0, ElementName=ProxyElement}" />
-										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="ContentRoot"
-											 BeginTime="0:0:0" To="1"/>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <HorizontalAlignment>Right</HorizontalAlignment>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <HorizontalAlignment>Left</HorizontalAlignment>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
+                                <VisualState x:Name="ClosedCompactLeft" Storyboard="{StaticResource ClosedCompactLeftStoryboard}" />
+                                <VisualState x:Name="ClosedCompactRight" Storyboard="{StaticResource ClosedCompactRightStoryboard}" />
+
+                                <VisualState x:Name="OpenOverlayLeft" Storyboard="{StaticResource OpenOverlayLeftStoryboard}" />
+                                <VisualState x:Name="OpenOverlayRight" Storyboard="{StaticResource OpenOverlayRightStoryboard}" />
+
+                                <VisualState x:Name="OpenInlineLeft" Storyboard="{StaticResource OpenInlineLeftStoryboard}" />
+                                <VisualState x:Name="OpenInlineRight" Storyboard="{StaticResource OpenInlineRightStoryboard}" />
+
+                                <VisualState x:Name="OpenCompactOverlayLeft" Storyboard="{StaticResource OpenCompactOverlayLeftStoryboard}" />
+                                <VisualState x:Name="OpenCompactOverlayRight" Storyboard="{StaticResource OpenCompactOverlayRightStoryboard}" />
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 						<FrameworkElement x:Name="ProxyElement" DataContext="{Binding TemplateSettings, RelativeSource={RelativeSource Mode=TemplatedParent}}"

--- a/src/UniversalWPF/Themes/Generic.xaml
+++ b/src/UniversalWPF/Themes/Generic.xaml
@@ -53,11 +53,19 @@
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Right"/>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Right</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
 											</ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Left"/>
-											</ObjectAnimationUsingKeyFrames>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Left</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
+                                            </ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
@@ -109,11 +117,19 @@
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Right"/>
-											</ObjectAnimationUsingKeyFrames>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Right</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
+                                            </ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Left"/>
-											</ObjectAnimationUsingKeyFrames>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Left</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
+                                            </ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
@@ -148,11 +164,19 @@
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Right"/>
-											</ObjectAnimationUsingKeyFrames>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Right</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
+                                            </ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Left"/>
-											</ObjectAnimationUsingKeyFrames>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Left</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
+                                            </ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
@@ -197,11 +221,19 @@
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Right"/>
-											</ObjectAnimationUsingKeyFrames>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Right</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
+                                            </ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Left"/>
-											</ObjectAnimationUsingKeyFrames>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                    <DiscreteObjectKeyFrame.Value>
+                                                        <HorizontalAlignment>Left</HorizontalAlignment>
+                                                    </DiscreteObjectKeyFrame.Value>
+                                                </DiscreteObjectKeyFrame>
+                                            </ObjectAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
 												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 											</ObjectAnimationUsingKeyFrames>
@@ -241,8 +273,12 @@
 										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
 											BeginTime="0:0:0" To="2" />
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Right"/>
-										</ObjectAnimationUsingKeyFrames>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <HorizontalAlignment>Right</HorizontalAlignment>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
 										<DoubleAnimation Duration="0:0:0" To="{Binding DataContext.OpenPaneLengthMinusCompactLength, ElementName=ProxyElement}" Storyboard.TargetProperty="X" Storyboard.TargetName="PaneClipRectangleTransform"/>
 									</Storyboard>
 								</VisualState>
@@ -265,14 +301,22 @@
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 										</ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Right"/>
-										</ObjectAnimationUsingKeyFrames>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <HorizontalAlignment>Right</HorizontalAlignment>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 										</ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Left"/>
-										</ObjectAnimationUsingKeyFrames>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <HorizontalAlignment>Left</HorizontalAlignment>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="LightDismissLayer">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 										</ObjectAnimationUsingKeyFrames>
@@ -310,8 +354,12 @@
 										<Int32Animation Storyboard.TargetProperty="(Grid.ColumnSpan)" Storyboard.TargetName="PaneRoot"
 											BeginTime="0:0:0" To="1"/>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Left"/>
-										</ObjectAnimationUsingKeyFrames>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <HorizontalAlignment>Left</HorizontalAlignment>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 										</ObjectAnimationUsingKeyFrames>
@@ -348,11 +396,19 @@
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 										</ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="PaneRoot">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Right"/>
-										</ObjectAnimationUsingKeyFrames>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <HorizontalAlignment>Right</HorizontalAlignment>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="HorizontalAlignment" Storyboard.TargetName="HCPaneBorder">
-											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Left"/>
-										</ObjectAnimationUsingKeyFrames>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <HorizontalAlignment>Left</HorizontalAlignment>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="HCPaneBorder">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
 										</ObjectAnimationUsingKeyFrames>


### PR DESCRIPTION
Hope this repo is not dead...

After playing with the SplitView I saw some nasty warnings and errors in the output console and the Placement doesn't works as expected.

Here my changes
- setting the `PanePlacement` at runtime produces `System.Windows.Media.Animation.AnimationException`, could be fixed by using the value explicit

```
System.Windows.Media.Animation.AnimationException was unhandled
  HResult=-2146233087
  Message=Cannot animate the 'HorizontalAlignment' property on a 'System.Windows.Shapes.Rectangle' using a 'System.Windows.Media.Animation.ObjectAnimationUsingKeyFrames'. For details see the inner exception.
  Source=PresentationCore
  StackTrace:
       at System.Windows.Media.Animation.AnimationStorage.OnCurrentTimeInvalidated(Object sender, EventArgs args)
       at System.Windows.Media.Animation.Clock.FireEvent(EventPrivateKey key)
       at System.Windows.Media.Animation.Clock.RaiseAccumulatedEvents()
       at System.Windows.Media.Animation.TimeManager.RaiseEnqueuedEvents()
       at System.Windows.Media.Animation.TimeManager.Tick()
       at System.Windows.Media.MediaContext.RenderMessageHandlerCore(Object resizedCompositionTarget)
       at System.Windows.Media.MediaContext.RenderMessageHandler(Object resizedCompositionTarget)
       at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
       at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
       at System.Windows.Threading.DispatcherOperation.InvokeImpl()
       at System.Windows.Threading.DispatcherOperation.InvokeInSecurityContext(Object state)
       at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
       at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
       at System.Windows.Threading.DispatcherOperation.Invoke()
       at System.Windows.Threading.Dispatcher.ProcessQueue()
       at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
       at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
       at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
       at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
       at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
       at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
       at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
       at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
       at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
       at System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
       at System.Windows.Application.RunDispatcher(Object ignore)
       at System.Windows.Application.RunInternal(Window window)
       at System.Windows.Application.Run(Window window)
       at System.Windows.Application.Run()
       at TestApp.App.Main() in d:\projects\git\UniversalWPF\src\TestApp\obj\Debug\App.g.cs:line 0
       at System.AppDomain._nExecuteAssembly(RuntimeAssembly assembly, String[] args)
       at System.AppDomain.ExecuteAssembly(String assemblyFile, Evidence assemblySecurity, String[] args)
       at Microsoft.VisualStudio.HostingProcess.HostProc.RunUsersAssembly()
       at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
       at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
       at System.Threading.ThreadHelper.ThreadStart()
  InnerException: 
       HResult=-2146233079
       Message=The animation(s) applied to the 'HorizontalAlignment' property calculate a current value of 'Left', which is not a valid value for the property.
       Source=PresentationCore
       StackTrace:
            at System.Windows.Media.Animation.AnimationStorage.GetCurrentPropertyValue(AnimationStorage storage, DependencyObject d, DependencyProperty dp, PropertyMetadata metadata, Object baseValue)
            at System.Windows.Media.Animation.AnimationStorage.OnCurrentTimeInvalidated(Object sender, EventArgs args)
       InnerException: 
```
- fix System.Windows.Data Error: 2 : Cannot find governing FrameworkElement or FrameworkContentElement for target element. this could be fixed by moving the Storyboards to the Grid.Resources

```
System.Windows.Data Error: 2 : Cannot find governing FrameworkElement or FrameworkContentElement for target element. BindingExpression:Path=DataContext.OpenPaneLength; DataItem=null; target element is 'SplineDoubleKeyFrame' (HashCode=57392070); target property is 'Value' (type 'Double')
System.Windows.Data Error: 2 : Cannot find governing FrameworkElement or FrameworkContentElement for target element. BindingExpression:Path=DataContext.NegativeOpenPaneLength; DataItem=null; target element is 'SplineDoubleKeyFrame' (HashCode=27210408); target property is 'Value' (type 'Double')
System.Windows.Data Error: 2 : Cannot find governing FrameworkElement or FrameworkContentElement for target element. BindingExpression:Path=DataContext.CompactPaneGridLength; DataItem=null; target element is 'GridLengthAnimation' (HashCode=60852213); target property is 'To' (type 'GridLength')
```
- fix System.Windows.Data Error: 1 : Cannot create default converter to perform 'one-way' conversions between types 'System.Windows.GridLength' and 'System.Nullable`1[System.Int32]'.

```
System.Windows.Data Error: 1 : Cannot create default converter to perform 'one-way' conversions between types 'System.Windows.GridLength' and 'System.Nullable`1[System.Int32]'. Consider using Converter property of Binding. BindingExpression:Path=DataContext.CompactPaneGridLength; DataItem='FrameworkElement' (Name='ProxyElement'); target element is 'Int32Animation' (HashCode=41975840); target property is 'To' (type 'Nullable`1')
```

Jan
